### PR TITLE
Optimize freeze rotation system

### DIFF
--- a/Assets/Scripts/ECS/Physics/FreezeRotationSystem.cs
+++ b/Assets/Scripts/ECS/Physics/FreezeRotationSystem.cs
@@ -1,4 +1,5 @@
-﻿using Unity.Entities;
+﻿using Ecosystem.ECS.Physics;
+using Unity.Entities;
 using Unity.Jobs;
 using Unity.Mathematics;
 using Unity.Physics;
@@ -8,12 +9,25 @@ using Unity.Physics;
 /// </summary>
 public class FreezeRotationSystem : SystemBase
 {
+    private EndSimulationEntityCommandBufferSystem m_EndSimulationEcbSystem;
+
+    protected override void OnCreate()
+    {
+        m_EndSimulationEcbSystem = World
+            .GetOrCreateSystem<EndSimulationEntityCommandBufferSystem>();
+    }
+
     protected override void OnUpdate()
     {
-        Entities.ForEach((ref PhysicsMass mass) =>
+        var commandBuffer = m_EndSimulationEcbSystem.CreateCommandBuffer().ToConcurrent();
+
+        Entities
+            .WithNone<FrozenRotation>()
+            .ForEach((Entity entity, int entityInQueryIndex, ref PhysicsMass mass) =>
         {
 
             mass.InverseInertia = float3.zero;
+            commandBuffer.AddComponent<FrozenRotation>(entityInQueryIndex, entity);
 
         }).ScheduleParallel();
     }

--- a/Assets/Scripts/ECS/Physics/FrozenRotation.cs
+++ b/Assets/Scripts/ECS/Physics/FrozenRotation.cs
@@ -1,0 +1,11 @@
+﻿using Unity.Entities;
+
+namespace Ecosystem.ECS.Physics
+{
+    /// <summary>
+    /// Physics rotation has been frozen for this entity.
+    /// </summary>
+    public struct FrozenRotation : IComponentData
+    {
+    }
+}

--- a/Assets/Scripts/ECS/Physics/FrozenRotation.cs.meta
+++ b/Assets/Scripts/ECS/Physics/FrozenRotation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52f40deea346b1c4c812bb44aa40ab05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Now the system doesn't keep running on entities that have already had
their rotation frozen.