### PR TITLE
GameZone is now called before ScenaryToTilemap

### DIFF
--- a/Assets/Scripts/Grid/GameZone.cs
+++ b/Assets/Scripts/Grid/GameZone.cs
@@ -35,7 +35,7 @@ namespace Ecosystem.Grid
 
 
         // Start is called before the first frame update
-        void Start() 
+        void Awake() 
         {
             InitObjects();
             RandomizeStartGrid();


### PR DESCRIPTION
GameZone is now called before ScenaryToTilemap, meaning that Scenary can be created based on the tiles from GameZone