### PR TITLE
Fix burst error

### DIFF
--- a/Assets/Scripts/ECS/Animal/Needs/HungerSystem.cs
+++ b/Assets/Scripts/ECS/Animal/Needs/HungerSystem.cs
@@ -27,10 +27,12 @@ namespace Ecosystem.ECS.Animal.Needs
         {
             var commandBuffer = m_EndSimulationEcbSystem.CreateCommandBuffer().ToConcurrent();
 
+            float deltaTime = Time.DeltaTime;
+
             Entities.ForEach((Entity entity, int entityInQueryIndex,
                 ref HungerData hungerData) =>
             {
-                hungerData.Hunger -= Time.DeltaTime / 1000.0f;
+                hungerData.Hunger -= deltaTime / 1000.0f;
 
                 if(hungerData.Hunger <= 0.0f)
                 {

--- a/Assets/Scripts/ECS/Animal/Needs/ThirstSystem.cs
+++ b/Assets/Scripts/ECS/Animal/Needs/ThirstSystem.cs
@@ -25,10 +25,12 @@ namespace Ecosystem.ECS.Animal.Needs
         {
             var commandBuffer = m_EndSimulationEcbSystem.CreateCommandBuffer().ToConcurrent();
 
+            float deltaTime = Time.DeltaTime;
+
             Entities.ForEach((Entity entity, int entityInQueryIndex,
                 ref ThirstData thirstData) =>
             {
-                thirstData.Thirst -= Time.DeltaTime / 1000.0f;
+                thirstData.Thirst -= deltaTime / 1000.0f;
 
                 if(thirstData.Thirst <= 0.0f)
                 {


### PR DESCRIPTION
You can't access the static property Time.DeltaTime in a burst-compiled ForEach. Fixed by storing it in a local field outside the ForEach.