### PR TITLE
Fix missing FoundMate method

### DIFF
--- a/Assets/Scripts/ECS/Hybrid/Sensors.cs
+++ b/Assets/Scripts/ECS/Hybrid/Sensors.cs
@@ -37,6 +37,7 @@ namespace Ecosystem.ECS.Hybrid
         public bool FoundFood() => GetComp<LookingForFood>().HasFound;
         public bool FoundPrey() => GetComp<LookingForPrey>().HasFound;
         public bool FoundPredator() => GetComp<LookingForPredator>().HasFound;
+        public bool FoundMate() => GetComp<LookingForMate>().HasFound;
 
 
 


### PR DESCRIPTION
This method was accidentally removed in some merge commit I think.