### PR TITLE
Added preprocessor check

### DIFF
--- a/Assets/Scripts/ECS/Debugging/HearingDebuggingSystem.cs
+++ b/Assets/Scripts/ECS/Debugging/HearingDebuggingSystem.cs
@@ -126,7 +126,9 @@ namespace Ecosystem.ECS.Debugging
                 typeof(CircleMesh),
                 typeof(ShapeStyle));
             EntityManager.SetSharedComponentData(hearingDebugEntityPrefab, new ShapeStyle { Material = Material });
+#if UNITY_EDITOR
             EntityManager.SetName(hearingDebugEntityPrefab, HEARING_DEBUG_ENTITY_NAME);
+#endif
         }
 
         private struct DisplayingHearingDebug : ISystemStateComponentData

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -119,7 +119,9 @@ PlayerSettings:
     16:9: 1
     Others: 1
   bundleVersion: 0.1
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 0}
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
SetName is only defined for the editor, leading to errors when trying to build. This adds a preprocessor check for the editor.