### PR TITLE
Change path material shader

### DIFF
--- a/Assets/Materials/Debugging/Path.mat
+++ b/Assets/Materials/Debugging/Path.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Path
-  m_Shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0


### PR DESCRIPTION
For some reason, the previous shader would be invisible when painted
over the tile textures.