### PR TITLE
Data-oriented grid systems

### DIFF
--- a/Assets/Scripts/ECS/Grid.meta
+++ b/Assets/Scripts/ECS/Grid.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c626ea6c89b413044af25ef7111107c5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ECS/Grid/CellOccupant.cs
+++ b/Assets/Scripts/ECS/Grid/CellOccupant.cs
@@ -1,0 +1,13 @@
+﻿using Unity.Entities;
+
+namespace Ecosystem.ECS.Grid
+{
+    /// <summary>
+    /// An entity that is occupying a cell in the world grid. A cell can only have one occupant.
+    /// </summary>
+    [GenerateAuthoringComponent]
+    public struct CellOccupant : IComponentData
+    {
+        public bool BlocksMovement; // If this entity blocks movement in its cell
+    }
+}

--- a/Assets/Scripts/ECS/Grid/CellOccupant.cs.meta
+++ b/Assets/Scripts/ECS/Grid/CellOccupant.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e660d1a060e19ec46b37ed971a1198b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ECS/Grid/CellOccupationSystem.cs
+++ b/Assets/Scripts/ECS/Grid/CellOccupationSystem.cs
@@ -33,7 +33,7 @@ namespace Ecosystem.ECS.Grid
                 .ForEach((Entity entity, int entityInQueryIndex,
                 in CellOccupant occupant, in Translation position) =>
                 {
-                    int2 gridPos = grid.GetGridPosition(position.Value); //gridPosition.Value;
+                    int2 gridPos = grid.GetGridPosition(position.Value);
                     int index = grid.GetCellIndex(gridPos);
 
                     if (occupiedCells[index]) return; // Already occupied

--- a/Assets/Scripts/ECS/Grid/CellOccupationSystem.cs
+++ b/Assets/Scripts/ECS/Grid/CellOccupationSystem.cs
@@ -1,0 +1,63 @@
+﻿using Ecosystem.ECS.Grid;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Sets cells in the world as occupied at every position where there is a cell occupant entity,
+/// and restores the cell after the entity is destroyed.
+/// </summary>
+public class CellOccupationSystem : SystemBase
+{
+    private EndSimulationEntityCommandBufferSystem m_EndSimulationEcbSystem;
+    private WorldGridSystem worldGridSystem;
+
+    protected override void OnCreate()
+    {
+        m_EndSimulationEcbSystem = World
+            .GetOrCreateSystem<EndSimulationEntityCommandBufferSystem>();
+        worldGridSystem = World.GetOrCreateSystem<WorldGridSystem>();
+    }
+
+    protected override void OnUpdate()
+    {
+        var commandBuffer = m_EndSimulationEcbSystem.CreateCommandBuffer().ToConcurrent();
+
+        var grid = worldGridSystem.Grid;
+        var occupiedCells = worldGridSystem.OccupiedCells;
+        var blockedCells = worldGridSystem.BlockedCells;
+
+        Entities
+            .WithNone<OccupyingCell>()
+            .ForEach((Entity entity, int entityInQueryIndex,
+            in CellOccupant occupant, in Translation position) =>
+            {
+                int2 gridPos = grid.GetGridPosition(position.Value); //gridPosition.Value;
+                int index = grid.GetCellIndex(gridPos);
+
+                if (occupiedCells[index]) return; // Already occupied
+
+                occupiedCells[index] = true;
+                blockedCells[index] = occupant.BlocksMovement;
+
+                commandBuffer.AddComponent(entityInQueryIndex, entity, new OccupyingCell
+                {
+                    Value = gridPos
+                });
+            }).ScheduleParallel();
+
+        Entities
+            .WithNone<CellOccupant>()
+            .ForEach((Entity entity, int entityInQueryIndex,
+            in OccupyingCell occupyingCell) =>
+            {
+                int index = grid.GetCellIndex(occupyingCell.Value);
+                occupiedCells[index] = false;
+                blockedCells[index] = false;
+
+                commandBuffer.RemoveComponent<OccupyingCell>(entityInQueryIndex, entity);
+            }).ScheduleParallel();
+
+        m_EndSimulationEcbSystem.AddJobHandleForProducer(Dependency);
+    }
+}

--- a/Assets/Scripts/ECS/Grid/CellOccupationSystem.cs
+++ b/Assets/Scripts/ECS/Grid/CellOccupationSystem.cs
@@ -1,63 +1,65 @@
-﻿using Ecosystem.ECS.Grid;
-using Unity.Entities;
+﻿using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
 
-/// <summary>
-/// Sets cells in the world as occupied at every position where there is a cell occupant entity,
-/// and restores the cell after the entity is destroyed.
-/// </summary>
-public class CellOccupationSystem : SystemBase
+namespace Ecosystem.ECS.Grid
 {
-    private EndSimulationEntityCommandBufferSystem m_EndSimulationEcbSystem;
-    private WorldGridSystem worldGridSystem;
-
-    protected override void OnCreate()
+    /// <summary>
+    /// Sets cells in the world as occupied at every position where there is a cell occupant entity,
+    /// and restores the cell after the entity is destroyed.
+    /// </summary>
+    public class CellOccupationSystem : SystemBase
     {
-        m_EndSimulationEcbSystem = World
-            .GetOrCreateSystem<EndSimulationEntityCommandBufferSystem>();
-        worldGridSystem = World.GetOrCreateSystem<WorldGridSystem>();
-    }
+        private EndSimulationEntityCommandBufferSystem m_EndSimulationEcbSystem;
+        private WorldGridSystem worldGridSystem;
 
-    protected override void OnUpdate()
-    {
-        var commandBuffer = m_EndSimulationEcbSystem.CreateCommandBuffer().ToConcurrent();
+        protected override void OnCreate()
+        {
+            m_EndSimulationEcbSystem = World
+                .GetOrCreateSystem<EndSimulationEntityCommandBufferSystem>();
+            worldGridSystem = World.GetOrCreateSystem<WorldGridSystem>();
+        }
 
-        var grid = worldGridSystem.Grid;
-        var occupiedCells = worldGridSystem.OccupiedCells;
-        var blockedCells = worldGridSystem.BlockedCells;
+        protected override void OnUpdate()
+        {
+            var commandBuffer = m_EndSimulationEcbSystem.CreateCommandBuffer().ToConcurrent();
 
-        Entities
-            .WithNone<OccupyingCell>()
-            .ForEach((Entity entity, int entityInQueryIndex,
-            in CellOccupant occupant, in Translation position) =>
-            {
-                int2 gridPos = grid.GetGridPosition(position.Value); //gridPosition.Value;
-                int index = grid.GetCellIndex(gridPos);
+            var grid = worldGridSystem.Grid;
+            var occupiedCells = worldGridSystem.OccupiedCells;
+            var blockedCells = worldGridSystem.BlockedCells;
 
-                if (occupiedCells[index]) return; // Already occupied
-
-                occupiedCells[index] = true;
-                blockedCells[index] = occupant.BlocksMovement;
-
-                commandBuffer.AddComponent(entityInQueryIndex, entity, new OccupyingCell
+            Entities
+                .WithNone<OccupyingCell>()
+                .ForEach((Entity entity, int entityInQueryIndex,
+                in CellOccupant occupant, in Translation position) =>
                 {
-                    Value = gridPos
-                });
-            }).ScheduleParallel();
+                    int2 gridPos = grid.GetGridPosition(position.Value); //gridPosition.Value;
+                    int index = grid.GetCellIndex(gridPos);
 
-        Entities
-            .WithNone<CellOccupant>()
-            .ForEach((Entity entity, int entityInQueryIndex,
-            in OccupyingCell occupyingCell) =>
-            {
-                int index = grid.GetCellIndex(occupyingCell.Value);
-                occupiedCells[index] = false;
-                blockedCells[index] = false;
+                    if (occupiedCells[index]) return; // Already occupied
 
-                commandBuffer.RemoveComponent<OccupyingCell>(entityInQueryIndex, entity);
-            }).ScheduleParallel();
+                    occupiedCells[index] = true;
+                    blockedCells[index] = occupant.BlocksMovement;
 
-        m_EndSimulationEcbSystem.AddJobHandleForProducer(Dependency);
+                    commandBuffer.AddComponent(entityInQueryIndex, entity, new OccupyingCell
+                    {
+                        Value = gridPos
+                    });
+                }).ScheduleParallel();
+
+            Entities
+                .WithNone<CellOccupant>()
+                .ForEach((Entity entity, int entityInQueryIndex,
+                in OccupyingCell occupyingCell) =>
+                {
+                    int index = grid.GetCellIndex(occupyingCell.Value);
+                    occupiedCells[index] = false;
+                    blockedCells[index] = false;
+
+                    commandBuffer.RemoveComponent<OccupyingCell>(entityInQueryIndex, entity);
+                }).ScheduleParallel();
+
+            m_EndSimulationEcbSystem.AddJobHandleForProducer(Dependency);
+        }
     }
 }

--- a/Assets/Scripts/ECS/Grid/CellOccupationSystem.cs.meta
+++ b/Assets/Scripts/ECS/Grid/CellOccupationSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83ef57921634da0419900883fdf79bae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ECS/Grid/EntityBucketSystem.cs
+++ b/Assets/Scripts/ECS/Grid/EntityBucketSystem.cs
@@ -1,0 +1,105 @@
+﻿using Ecosystem.ECS.Animal;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace Ecosystem.ECS.Grid
+{
+    /// <summary>
+    /// Sorts entities into buckets based on position.
+    /// <para/>
+    /// Buckets are used to optimize search for nearby entities by only looking at entities in nearby
+    /// buckets.
+    /// </summary>
+    public class EntityBucketSystem : SystemBase
+    {
+        private const int CELL_SIZE = 20; // Bucket area = CELL_SIZE ^ 2
+
+        public NativeMultiHashMap<int, Entity> AnimalBuckets;
+        public NativeMultiHashMap<int, Entity> FoodBuckets;
+
+        private GridData grid;
+
+        private EntityQuery animalQuery;
+        private EntityQuery foodQuery;
+
+        /// <summary>
+        /// Returns keys to all nearby buckets.
+        /// <para/>
+        /// Guaranteed to cover all buckets within the specified radius of the specified world position.
+        /// </summary>
+        public int[] GetNearbyCellsKeys(float3 worldPosition, float radius)
+        {
+            float3 startPos = worldPosition + new float3(-radius, 0, -radius);
+            float3 endPos = worldPosition + new float3(radius, 0, radius);
+            int2 start = grid.GetGridPosition(startPos);
+            int2 end = grid.GetGridPosition(endPos);
+
+            int[] nearbyCellKeys = new int[(1 + end.x - start.x) * (1 + end.y - start.y)];
+
+            int index = 0;
+            for (int i = start.x; i <= end.x; i++)
+            {
+                for (int j = start.y; j <= end.y; j++)
+                {
+                    nearbyCellKeys[index] = grid.GetCellKey(new int2(i, j));
+                    index++;
+                }
+            }
+
+            return nearbyCellKeys;
+        }
+
+        protected override void OnCreate()
+        {
+            grid = new GridData(CELL_SIZE);
+            AnimalBuckets = new NativeMultiHashMap<int, Entity>(0, Allocator.Persistent);
+            FoodBuckets = new NativeMultiHashMap<int, Entity>(0, Allocator.Persistent);
+
+            animalQuery = GetEntityQuery(typeof(AnimalTypeData));
+            foodQuery = GetEntityQuery(typeof(FoodTypeData));
+        }
+
+        protected override void OnDestroy()
+        {
+            AnimalBuckets.Dispose();
+            FoodBuckets.Dispose();
+        }
+
+        protected override void OnUpdate()
+        {
+            GridData grid = this.grid;
+
+            ResetBuckets();
+
+            var animalBucketsWriter = AnimalBuckets.AsParallelWriter();
+            Entities
+                .WithAll<AnimalTypeData>()
+                .ForEach((Entity entity, in Translation position) =>
+                {
+                    animalBucketsWriter.Add(grid.GetCellKey(position.Value), entity);
+                }).ScheduleParallel();
+
+            var foodBucketsWriter = FoodBuckets.AsParallelWriter();
+            Entities
+                .WithAll<FoodTypeData>()
+                .ForEach((Entity entity, in Translation position) =>
+                {
+                    foodBucketsWriter.Add(grid.GetCellKey(position.Value), entity);
+                }).ScheduleParallel();
+        }
+
+        private void ResetBuckets()
+        {
+            AnimalBuckets.Clear();
+            FoodBuckets.Clear();
+
+            int animalCount = animalQuery.CalculateEntityCount();
+            int foodCount = foodQuery.CalculateEntityCount();
+
+            if (animalCount > AnimalBuckets.Capacity) AnimalBuckets.Capacity = animalCount;
+            if (foodCount > FoodBuckets.Capacity) FoodBuckets.Capacity = foodCount;
+        }
+    }
+}

--- a/Assets/Scripts/ECS/Grid/EntityBucketSystem.cs.meta
+++ b/Assets/Scripts/ECS/Grid/EntityBucketSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5bbd44819f1abc47827722fcbec552f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ECS/Grid/GridData.cs
+++ b/Assets/Scripts/ECS/Grid/GridData.cs
@@ -1,0 +1,66 @@
+﻿using Unity.Mathematics;
+
+namespace Ecosystem.ECS.Grid
+{
+    public struct GridData
+    {
+        private int width;
+        private int height;
+        private float cellSize;
+
+        public int Length => width * height;
+
+        public GridData(int width, int height, float cellSize = 1f)
+        {
+            this.width = width;
+            this.height = height;
+            this.cellSize = cellSize;
+        }
+
+        /// <summary>
+        /// If not interested in the indexing, such as if used for a hash map.
+        /// </summary>
+        public GridData(float cellSize) : this(0, 0, cellSize) { }
+
+        public int2 GetGridPosition(float3 worldPosition)
+        {
+            int x = (int)math.floor(worldPosition.x / cellSize);
+            int z = (int)math.floor(worldPosition.z / cellSize);
+
+            return new int2(x, z);
+        }
+
+        public bool IsInBounds(float3 worldPosition)
+        {
+            int2 gridPosition = GetGridPosition(worldPosition);
+            int x = gridPosition.x;
+            int z = gridPosition.y;
+            return x >= 0 && z >= 0 && x < width && z < height;
+        }
+
+        /// <summary>
+        /// Returns the converted one-dimensional index for the cell at the specified position.
+        /// <para/>
+        /// Works for every cell within the bounds of this grid.
+        /// </summary>
+        public int GetCellIndex(float3 worldPosition) => GetCellIndex(GetGridPosition(worldPosition));
+        public int GetCellIndex(int2 gridPosition) => GetCellIndex(gridPosition.x, gridPosition.y);
+        private int GetCellIndex(int x, int z) => z * width + x;
+
+        /// <summary>
+        /// Returns a unique key for the cell at the specified position.
+        /// <para/>
+        /// Useful as keys in a hash map. Works anywhere in the world without the need of
+        /// a width/height in the grid.
+        /// <para/>
+        /// Uses the Cantor pairing function to generate a unique number for each pair of numbers.
+        /// </summary>
+        public int GetCellKey(float3 worldPosition) => GetCellKey(GetGridPosition(worldPosition));
+        public int GetCellKey(int2 gridPosition)
+        {
+            int a = gridPosition.x;
+            int b = gridPosition.y;
+            return (a + b) * (a + b + 1) / 2 + b;
+        }
+    }
+}

--- a/Assets/Scripts/ECS/Grid/GridData.cs.meta
+++ b/Assets/Scripts/ECS/Grid/GridData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6648c554968ffdd44b9ba7de6bd09c64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ECS/Grid/OccupyingCell.cs
+++ b/Assets/Scripts/ECS/Grid/OccupyingCell.cs
@@ -1,0 +1,13 @@
+﻿using Unity.Entities;
+using Unity.Mathematics;
+
+namespace Ecosystem.ECS.Grid
+{
+    /// <summary>
+    /// Currently occupying a cell in the world grid.
+    /// </summary>
+    public struct OccupyingCell : ISystemStateComponentData
+    {
+        public int2 Value; // The cell that this entity occupies
+    }
+}

--- a/Assets/Scripts/ECS/Grid/OccupyingCell.cs.meta
+++ b/Assets/Scripts/ECS/Grid/OccupyingCell.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb1141cadb572504f904321d012238d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ECS/Grid/WorldGridSystem.cs
+++ b/Assets/Scripts/ECS/Grid/WorldGridSystem.cs
@@ -1,61 +1,63 @@
-﻿using Ecosystem.ECS.Grid;
-using Unity.Collections;
+﻿using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 
-/// <summary>
-/// Holds info about the world grid.
-/// </summary>
-public class WorldGridSystem : SystemBase
+namespace Ecosystem.ECS.Grid
 {
-    public GridData Grid;
-
-    public NativeArray<bool> OccupiedCells;
-    public NativeArray<bool> BlockedCells;
-    public NativeArray<bool> WaterCells;
-
     /// <summary>
-    /// Sets a cell as occupied.
+    /// Holds info about the world grid.
     /// </summary>
-    public void SetOccupiedCell(int2 gridPos, bool blocksMovement = false)
+    public class WorldGridSystem : SystemBase
     {
-        OccupiedCells[Grid.GetCellIndex(gridPos)] = true;
-        BlockedCells[Grid.GetCellIndex(gridPos)] = blocksMovement;
-    }
+        public GridData Grid;
 
-    /// <summary>
-    /// Sets a cell as water.
-    /// </summary>
-    public void SetWaterCell(int2 gridPos) => WaterCells[Grid.GetCellIndex(gridPos)] = true;
+        public NativeArray<bool> OccupiedCells;
+        public NativeArray<bool> BlockedCells;
+        public NativeArray<bool> WaterCells;
 
-    protected override void OnCreate()
-    {
-        InitGrid(100, 100); // Default grid
-    }
+        /// <summary>
+        /// Sets a cell as occupied.
+        /// </summary>
+        public void SetOccupiedCell(int2 gridPos, bool blocksMovement = false)
+        {
+            OccupiedCells[Grid.GetCellIndex(gridPos)] = true;
+            BlockedCells[Grid.GetCellIndex(gridPos)] = blocksMovement;
+        }
 
-    /// <summary>
-    /// Initializes the grid with amount of columns/rows equal to the specified width/height.
-    /// </summary>
-    public void InitGrid(int width, int height, float cellSize = 1f)
-    {
-        Grid = new GridData(width, height, cellSize);
+        /// <summary>
+        /// Sets a cell as water.
+        /// </summary>
+        public void SetWaterCell(int2 gridPos) => WaterCells[Grid.GetCellIndex(gridPos)] = true;
 
-        if (OccupiedCells.IsCreated) OccupiedCells.Dispose();
-        if (BlockedCells.IsCreated) BlockedCells.Dispose();
-        if (WaterCells.IsCreated) WaterCells.Dispose();
-        OccupiedCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
-        BlockedCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
-        WaterCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
-    }
+        protected override void OnCreate()
+        {
+            InitGrid(100, 100); // Default grid
+        }
 
-    protected override void OnDestroy()
-    {
-        OccupiedCells.Dispose();
-        BlockedCells.Dispose();
-        WaterCells.Dispose();
-    }
+        /// <summary>
+        /// Initializes the grid with amount of columns/rows equal to the specified width/height.
+        /// </summary>
+        public void InitGrid(int width, int height, float cellSize = 1f)
+        {
+            Grid = new GridData(width, height, cellSize);
 
-    protected override void OnUpdate()
-    {
+            if (OccupiedCells.IsCreated) OccupiedCells.Dispose();
+            if (BlockedCells.IsCreated) BlockedCells.Dispose();
+            if (WaterCells.IsCreated) WaterCells.Dispose();
+            OccupiedCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
+            BlockedCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
+            WaterCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
+        }
+
+        protected override void OnDestroy()
+        {
+            OccupiedCells.Dispose();
+            BlockedCells.Dispose();
+            WaterCells.Dispose();
+        }
+
+        protected override void OnUpdate()
+        {
+        }
     }
 }

--- a/Assets/Scripts/ECS/Grid/WorldGridSystem.cs
+++ b/Assets/Scripts/ECS/Grid/WorldGridSystem.cs
@@ -1,0 +1,61 @@
+﻿using Ecosystem.ECS.Grid;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Holds info about the world grid.
+/// </summary>
+public class WorldGridSystem : SystemBase
+{
+    public GridData Grid;
+
+    public NativeArray<bool> OccupiedCells;
+    public NativeArray<bool> BlockedCells;
+    public NativeArray<bool> WaterCells;
+
+    /// <summary>
+    /// Sets a cell as occupied.
+    /// </summary>
+    public void SetOccupiedCell(int2 gridPos, bool blocksMovement = false)
+    {
+        OccupiedCells[Grid.GetCellIndex(gridPos)] = true;
+        BlockedCells[Grid.GetCellIndex(gridPos)] = blocksMovement;
+    }
+
+    /// <summary>
+    /// Sets a cell as water.
+    /// </summary>
+    public void SetWaterCell(int2 gridPos) => WaterCells[Grid.GetCellIndex(gridPos)] = true;
+
+    protected override void OnCreate()
+    {
+        InitGrid(100, 100); // Default grid
+    }
+
+    /// <summary>
+    /// Initializes the grid with amount of columns/rows equal to the specified width/height.
+    /// </summary>
+    public void InitGrid(int width, int height, float cellSize = 1f)
+    {
+        Grid = new GridData(width, height, cellSize);
+
+        if (OccupiedCells.IsCreated) OccupiedCells.Dispose();
+        if (BlockedCells.IsCreated) BlockedCells.Dispose();
+        if (WaterCells.IsCreated) WaterCells.Dispose();
+        OccupiedCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
+        BlockedCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
+        WaterCells = new NativeArray<bool>(Grid.Length, Allocator.Persistent);
+    }
+
+    protected override void OnDestroy()
+    {
+        OccupiedCells.Dispose();
+        BlockedCells.Dispose();
+        WaterCells.Dispose();
+    }
+
+    protected override void OnUpdate()
+    {
+    }
+}

--- a/Assets/Scripts/ECS/Grid/WorldGridSystem.cs.meta
+++ b/Assets/Scripts/ECS/Grid/WorldGridSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2eb58672728ea9940b01bb517d358483
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds a world grid system as well as an entity bucket system, both based on a grid struct.

The world grid system holds info of the tiles in the world (e.g., what is water, what tiles block movement) and provides an easy access point for other systems. This is not really different from the previous solution but it has less concerns and accessing the grid through the system feels nicer than through static variables.

Entities can now be attached with a "CellOccupant" component to automatically be added to the grid as occupying a cell and blocking movement.

The bucket system works by placing entities into "buckets" (basically lists) based on their position, meaning nearby entities will be in the same bucket. This can be used to optimize all systems that search for other entities within an area by only looking for entities in adjacent buckets instead of every entity in the world.