### PR TITLE
Fix double death event

### DIFF
--- a/Assets/Scripts/ECS/Animal/AgingSystem.cs
+++ b/Assets/Scripts/ECS/Animal/AgingSystem.cs
@@ -23,20 +23,21 @@ namespace Ecosystem.ECS.Animal
             float deltaTime = Time.DeltaTime/60;
 
             Entities
-            .ForEach((int nativeThreadIndex, Entity entity, int entityInQueryIndex,
-            ref AgeData age,
-            in AgeOfDeathData ageOfDeath) =>
-            {
-
-                // Store age in seconds.
-                age.Age += deltaTime;
-                if (age.Age >= ageOfDeath.Value)
+                .WithNone<DeathEvent>()
+                .ForEach((int nativeThreadIndex, Entity entity, int entityInQueryIndex,
+                ref AgeData age,
+                in AgeOfDeathData ageOfDeath) =>
                 {
-                    // Death by old age.
-                    commandBuffer.AddComponent<DeathEvent>(entityInQueryIndex, entity,new DeathEvent(DeathCause.Age));
-                }
+
+                    // Store age in seconds.
+                    age.Age += deltaTime;
+                    if (age.Age >= ageOfDeath.Value)
+                    {
+                        // Death by old age.
+                        commandBuffer.AddComponent<DeathEvent>(entityInQueryIndex, entity,new DeathEvent(DeathCause.Age));
+                    }
                 
-            }).ScheduleParallel();
+                }).ScheduleParallel();
 
             m_EndSimulationEcbSystem.AddJobHandleForProducer(Dependency);
         }

--- a/Assets/Scripts/ECS/Animal/Needs/HungerSystem.cs
+++ b/Assets/Scripts/ECS/Animal/Needs/HungerSystem.cs
@@ -22,17 +22,19 @@ namespace Ecosystem.ECS.Animal.Needs
 
             float deltaTime = Time.DeltaTime/60f;
 
-            Entities.ForEach((Entity entity, int entityInQueryIndex,
+            Entities
+                .WithNone<DeathEvent>()
+                .ForEach((Entity entity, int entityInQueryIndex,
                 ref HungerData hungerData) =>
-            {
-                hungerData.Hunger -= deltaTime;
-
-                if(hungerData.Hunger <= 0.0f)
                 {
-                    commandBuffer.AddComponent<DeathEvent>(entityInQueryIndex, entity,new DeathEvent(DeathCause.Hunger));
-                }
+                    hungerData.Hunger -= deltaTime;
 
-            }).ScheduleParallel();
+                    if(hungerData.Hunger <= 0.0f)
+                    {
+                        commandBuffer.AddComponent<DeathEvent>(entityInQueryIndex, entity,new DeathEvent(DeathCause.Hunger));
+                    }
+
+                }).ScheduleParallel();
 
             m_EndSimulationEcbSystem.AddJobHandleForProducer(Dependency);
         }

--- a/Assets/Scripts/ECS/Animal/Needs/ThirstSystem.cs
+++ b/Assets/Scripts/ECS/Animal/Needs/ThirstSystem.cs
@@ -22,17 +22,19 @@ namespace Ecosystem.ECS.Animal.Needs
 
             float deltaTime = Time.DeltaTime/60f;
 
-            Entities.ForEach((Entity entity, int entityInQueryIndex,
+            Entities
+                .WithNone<DeathEvent>()
+                .ForEach((Entity entity, int entityInQueryIndex,
                 ref ThirstData thirstData) =>
-            {
-                thirstData.Thirst -= deltaTime;
-
-                if(thirstData.Thirst <= 0.0f)
                 {
-                    commandBuffer.AddComponent<DeathEvent>(entityInQueryIndex, entity,new DeathEvent(DeathCause.Thirst));
-                }
+                    thirstData.Thirst -= deltaTime;
 
-            }).ScheduleParallel();
+                    if(thirstData.Thirst <= 0.0f)
+                    {
+                        commandBuffer.AddComponent<DeathEvent>(entityInQueryIndex, entity,new DeathEvent(DeathCause.Thirst));
+                    }
+
+                }).ScheduleParallel();
 
             m_EndSimulationEcbSystem.AddJobHandleForProducer(Dependency);
         }


### PR DESCRIPTION
The systems that add the death event would add another death event in the next frame causing the command buffer to first remove the entity with the death event and then try to add a new death event to the entity that is now removed.