### PR TITLE
Add baby prefab to animal type

### DIFF
--- a/Assets/Gameplay/AnimalTypes/Eagle.asset
+++ b/Assets/Gameplay/AnimalTypes/Eagle.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Eagle
   m_EditorClassIdentifier: 
   Meat: {fileID: 0}
+  Baby: {fileID: 0}
   Name: Eagle
   prey: []
   food:

--- a/Assets/Gameplay/AnimalTypes/Fish.asset
+++ b/Assets/Gameplay/AnimalTypes/Fish.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Fish
   m_EditorClassIdentifier: 
   Meat: {fileID: 0}
+  Baby: {fileID: 0}
   Name: Fish
   prey: []
   food: []

--- a/Assets/Gameplay/AnimalTypes/Fox.asset
+++ b/Assets/Gameplay/AnimalTypes/Fox.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Fox
   m_EditorClassIdentifier: 
   Meat: {fileID: 4278235268764069113, guid: 5c06864f96393a54ab762927f594de4f, type: 3}
+  Baby: {fileID: 237763005265493658, guid: 3e63c95c8826a4b45875d7335c4840d0, type: 3}
   Name: Fox
   prey:
   - {fileID: 11400000, guid: bdd7a7559f0396f4f86fb7ae5a3d8b3d, type: 2}

--- a/Assets/Gameplay/AnimalTypes/Rabbit.asset
+++ b/Assets/Gameplay/AnimalTypes/Rabbit.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: Rabbit
   m_EditorClassIdentifier: 
   Meat: {fileID: 6036045412324625326, guid: 1e985e15736829647affb3f1e42c6439, type: 3}
+  Baby: {fileID: 4356907975632342146, guid: d926564931b9643789a1f64382be8263, type: 3}
   Name: Rabbit
   prey: []
   food:

--- a/Assets/ScriptableObjects/Gameplay/AnimalType.cs
+++ b/Assets/ScriptableObjects/Gameplay/AnimalType.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Ecosystem.Attributes;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Ecosystem.Gameplay
@@ -8,6 +9,9 @@ namespace Ecosystem.Gameplay
     {
         [Tooltip("The meat that comes from this animal")]
         public GameObject Meat;
+
+        [Tooltip("The prefab that this animal spawns babies from")]
+        public Animal Baby;
 
         [Tooltip("The name of this animal (Fox,Rabbit,Fish,Eagle)")]
         public string Name;

--- a/Assets/Scripts/ECS/Animal/Authoring/AnimalTypeAuthoring.cs
+++ b/Assets/Scripts/ECS/Animal/Authoring/AnimalTypeAuthoring.cs
@@ -23,6 +23,11 @@ namespace Ecosystem.ECS.Animal
                 Prefab = conversionSystem.GetPrimaryEntity(animalType.Meat)
             });
 
+            dstManager.AddComponentData(entity, new AnimalPrefab
+            {
+                Prefab = animalType.Baby
+            });
+
             DynamicBuffer<PreyTypesElement> preyBuffer = dstManager.AddBuffer<PreyTypesElement>(entity);
             foreach (AnimalType animalType in animalType.Prey)
             {


### PR DESCRIPTION
Prefabs referencing themselves caused Unity to crash so now they are stored in their corresponding animal type scriptable objects instead.