### PR TITLE
Update flee state

### DIFF
--- a/Assets/Scripts/Attributes/Animal.cs
+++ b/Assets/Scripts/Attributes/Animal.cs
@@ -86,14 +86,14 @@ namespace Ecosystem.Attributes
             float currentMating = this.needs.GetSexualUrgesStatus();
 
             sensors.LookForPredator(true);
+            sensors.LookForFleeTarget(sensors.FoundPredator());
             sensors.LookForPrey(currentHunger <= hungerLimit);
             sensors.LookForFood(currentHunger <= hungerLimit);
             sensors.LookForWater(currentThirst <= thirstLimit);
             sensors.LookForMate(currentMating <= matingLimit);
 
-            if (sensors.FoundPredator())
+            if (sensors.FoundFleeTarget())
             {
-                sensors.LookForFleeTarget(true);
                 if (stateMachine.getCurrentState() != this.fleeState)
                 {
                     stateMachine.ChangeState(this.fleeState);

--- a/Assets/Scripts/ECS/Targeting/FindSystems/FindFleeTargetSystem.cs
+++ b/Assets/Scripts/ECS/Targeting/FindSystems/FindFleeTargetSystem.cs
@@ -42,7 +42,7 @@ namespace Ecosystem.ECS.Targeting.FindSystems {
                     in Translation translation,
                     in MovementTerrain movementTerrain) =>
                 {
-                    if (!lookingForPredator.HasFound) return; // No predator to run from
+                    if (!lookingForPredator.HasFound) return; // No predator to flee from
 
                     bool onLand = movementTerrain.MovesOnLand;
                     bool inWater = movementTerrain.MovesOnWater;

--- a/Assets/Scripts/ECS/Targeting/FindSystems/FindFleeTargetSystem.cs
+++ b/Assets/Scripts/ECS/Targeting/FindSystems/FindFleeTargetSystem.cs
@@ -42,6 +42,8 @@ namespace Ecosystem.ECS.Targeting.FindSystems {
                     in Translation translation,
                     in MovementTerrain movementTerrain) =>
                 {
+                    if (!lookingForPredator.HasFound) return; // No predator to run from
+
                     bool onLand = movementTerrain.MovesOnLand;
                     bool inWater = movementTerrain.MovesOnWater;
 

--- a/Assets/Scripts/StateMachine/FleeState.cs
+++ b/Assets/Scripts/StateMachine/FleeState.cs
@@ -17,15 +17,12 @@ namespace Ecosystem.StateMachines {
         public void Enter() {
             // Starts sprint
             owner.GetMovement().Sprint(true);
-            owner.GetSensors().LookForFleeTarget(true);
         }
 
         public void Execute() {
             timeSinceLastFrame += Time.deltaTime;
             if (timeSinceLastFrame < pathfindInterval) return;
             timeSinceLastFrame = 0f;
-
-            if (!owner.GetSensors().FoundFleeTarget()) return;
 
             nextTarget = owner.GetSensors().GetFoundFleeTargetInfo();
             owner.Move(nextTarget,0f,200);
@@ -34,7 +31,6 @@ namespace Ecosystem.StateMachines {
         public void Exit() {
             // End sprint
             owner.GetMovement().Sprint(false);
-            owner.GetSensors().LookForFleeTarget(false);
         }
     }
 }


### PR DESCRIPTION
Only enter flee state if a predator **and** a flee target has been found. If an animal can't find a position to flee to, it will continue in whatever state it was in, instead of just standing still.

Also added a check if a predator has been found in "FindFleeTargetSystem" to avoid potential errors when getting its position.