### PR TITLE
Fix death event order

### DIFF
--- a/Assets/Scripts/ECS/Death/DeathEventSystem.cs
+++ b/Assets/Scripts/ECS/Death/DeathEventSystem.cs
@@ -5,6 +5,7 @@ namespace Ecosystem.ECS.Death
     /// <summary>
     /// Kills desired entities
     /// </summary>
+    [UpdateInGroup(typeof(LateSimulationSystemGroup))]
     public class DeathEventSystem : SystemBase
     {
         EndSimulationEntityCommandBufferSystem m_EndSimulationEcbSystem;


### PR DESCRIPTION
When DeathEventSystem runs before other systems that also use the command buffer, in the playback of the command buffer, the entity gets removed before other commands try to add/remove components to the entity, causing "null entity" errors.

Now DeathEventSystem always runs late in the SimulationSystemGroup.