### PR TITLE
Fix adding data points for empty animal counts

### DIFF
--- a/Assets/Scripts/Graphs/AverageAnimalStats.cs
+++ b/Assets/Scripts/Graphs/AverageAnimalStats.cs
@@ -59,7 +59,6 @@ namespace Ecosystem.Graphs
         {
             foreach (var pair in animalStatValueSums)
             {
-                if (pair.Value.Count == 0) continue;
                 AddDataPoint(timestamp, pair.Key, pair.Value.Count);
             }
             Clear();


### PR DESCRIPTION
Unlike when counting the average for animals' stats, when counting the amount of animals alive, it is important to capture when they go extinct.