### PR TITLE
Fix simulation settings sending error messages randomly

### DIFF
--- a/Assets/ScriptableObjects/Console/Commands/InitialPopulationCommand.cs
+++ b/Assets/ScriptableObjects/Console/Commands/InitialPopulationCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Linq;
+using System.Text;
 using UnityEngine;
 
 namespace Ecosystem.Console
@@ -15,7 +16,7 @@ namespace Ecosystem.Console
             {
                 StringBuilder sb = new StringBuilder();
                 sb.Append("Initial populations:");
-                foreach (var pop in simulationSettings.InitialPopulations.Values)
+                foreach (var pop in simulationSettings.InitialPopulations)
                 {
                     sb.Append("\n    ").Append(pop.Prefab.name).Append(": ").Append(pop.Amount);
                 }
@@ -25,7 +26,7 @@ namespace Ecosystem.Console
 
             if (args.Length == 1 && args[0] == "clear")
             {
-                foreach (var pop in simulationSettings.InitialPopulations.Values) pop.Amount = 0;
+                foreach (var pop in simulationSettings.InitialPopulations) pop.Amount = 0;
                 sender.SendMessage("All initial populations set to 0");
                 return;
             }
@@ -33,7 +34,9 @@ namespace Ecosystem.Console
             if (args.Length != 2) return;
             var prefabName = args[0].ToLower();
 
-            if (!simulationSettings.InitialPopulations.TryGetValue(prefabName, out var population))
+            var population = simulationSettings.InitialPopulations.SingleOrDefault(x => x.Prefab.name == prefabName);
+            
+            if (population == null)
             {
                 sender.SendMessage("Could not find \"" + prefabName + "\"");
                 return;

--- a/Assets/ScriptableObjects/Console/Commands/SpawnCommand.cs
+++ b/Assets/ScriptableObjects/Console/Commands/SpawnCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Ecosystem.ECS.Grid;
+using System.Linq;
 using Unity.Entities;
 using UnityEngine;
 
@@ -21,12 +22,15 @@ namespace Ecosystem.Console
                 sender.SendMessage("Not a number: " + args[1], MessageType.Error);
                 return;
             }
-            
-            if (!simulationSettings.InitialPopulations.TryGetValue(prefabName, out var population))
+
+            var population = simulationSettings.InitialPopulations.SingleOrDefault(x => x.Prefab.name == prefabName);
+
+            if (population == null)
             {
                 sender.SendMessage("Could not find \"" + prefabName + "\"");
                 return;
             }
+
             var prefab = population.Prefab;
 
             if (worldGridSystem == null) worldGridSystem = World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<WorldGridSystem>();

--- a/Assets/ScriptableObjects/Gameplay/SimulationSettings.cs
+++ b/Assets/ScriptableObjects/Gameplay/SimulationSettings.cs
@@ -10,16 +10,7 @@ namespace Ecosystem
         [SerializeField]
         private List<AnimalPopulation> initialPopulations = new List<AnimalPopulation>();
 
-        public Dictionary<string, AnimalPopulation> InitialPopulations { get; } = new Dictionary<string, AnimalPopulation>();
-
-        private void OnEnable()
-        {
-            InitialPopulations.Clear();
-            foreach (var population in initialPopulations)
-            {
-                InitialPopulations.Add(population.Prefab.name.ToLower(), population);
-            }
-        }
+        public List<AnimalPopulation> InitialPopulations => initialPopulations;
 
         [Serializable]
         public class AnimalPopulation

--- a/Assets/Scripts/Spawner/PrefabSpawner.cs
+++ b/Assets/Scripts/Spawner/PrefabSpawner.cs
@@ -28,7 +28,7 @@ public class PrefabSpawner : MonoBehaviour
         // For each prefab find a free spot and spawn the gameobject
         foreach (var population in settings.InitialPopulations)
         {
-            Spawn(population.Value.Prefab, population.Value.Amount);
+            Spawn(population.Prefab, population.Amount);
         }
     }
 


### PR DESCRIPTION
Referencing prefabs in the ScriptableObject's OnEnable caused it to sometimes send error messages even though it works in play mode. Sticking with list over dictionary to avoid those annoying messages.