### PR TITLE
Fix spawn command ignore case

### DIFF
--- a/Assets/ScriptableObjects/Console/Commands/SpawnCommand.cs
+++ b/Assets/ScriptableObjects/Console/Commands/SpawnCommand.cs
@@ -23,7 +23,8 @@ namespace Ecosystem.Console
                 return;
             }
 
-            var population = simulationSettings.InitialPopulations.SingleOrDefault(x => x.Prefab.name == prefabName);
+            var population = simulationSettings.InitialPopulations.SingleOrDefault(
+                x => x.Prefab.name.Equals(prefabName, System.StringComparison.OrdinalIgnoreCase));
 
             if (population == null)
             {

--- a/Assets/ScriptableObjects/Console/Commands/SpawnCommand.cs
+++ b/Assets/ScriptableObjects/Console/Commands/SpawnCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Ecosystem.ECS.Grid;
 using System.Linq;
+using System.Text;
 using Unity.Entities;
 using UnityEngine;
 
@@ -29,6 +30,7 @@ namespace Ecosystem.Console
             if (population == null)
             {
                 sender.SendMessage("Could not find \"" + prefabName + "\"");
+                sender.SendMessage(GetAvailableAnimals());
                 return;
             }
 
@@ -38,6 +40,17 @@ namespace Ecosystem.Console
 
             PrefabSpawner.Spawn(prefab, amount, worldGridSystem);
             sender.SendMessage("Spawned " + amount + " " + prefab.name + "s");
+        }
+
+        private string GetAvailableAnimals()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("Available animals:");
+            foreach (var pop in simulationSettings.InitialPopulations)
+            {
+                sb.Append("\n    " + pop.Prefab.name);
+            }
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
Spawn command is now case insensitive again when choosing what animal to spawn and if the animal is not found, a list of available animals is returned.