### PR TITLE
Poisson disc sampling

### DIFF
--- a/Assets/Scenes/Main_scene.unity
+++ b/Assets/Scenes/Main_scene.unity
@@ -698,7 +698,12 @@ PrefabInstance:
     - target: {fileID: -7102660320631865697, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7102660320631865697, guid: 3d6571ed8ced74e4cad067533607be38,
+        type: 3}
+      propertyPath: R
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 1022454915255237003, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}
@@ -728,7 +733,7 @@ PrefabInstance:
     - target: {fileID: 1022454915255237108, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}
       propertyPath: Lacunarity
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1022454915255237108, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}

--- a/Assets/Scenes/Main_scene.unity
+++ b/Assets/Scenes/Main_scene.unity
@@ -705,6 +705,16 @@ PrefabInstance:
       propertyPath: R
       value: 100
       objectReference: {fileID: 0}
+    - target: {fileID: -7102660320631865697, guid: 3d6571ed8ced74e4cad067533607be38,
+        type: 3}
+      propertyPath: min_radius
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7102660320631865697, guid: 3d6571ed8ced74e4cad067533607be38,
+        type: 3}
+      propertyPath: max_radius
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 1022454915255237003, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}
       propertyPath: m_Name
@@ -743,7 +753,17 @@ PrefabInstance:
     - target: {fileID: 1022454915255237108, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}
       propertyPath: RandomNoiseSeed
-      value: 0
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1022454915255237108, guid: 3d6571ed8ced74e4cad067533607be38,
+        type: 3}
+      propertyPath: min_radius
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1022454915255237108, guid: 3d6571ed8ced74e4cad067533607be38,
+        type: 3}
+      propertyPath: max_radius
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1022454915255237109, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}

--- a/Assets/Scripts/Grid/GameZone.cs
+++ b/Assets/Scripts/Grid/GameZone.cs
@@ -33,10 +33,10 @@ namespace Ecosystem.Grid
         // //The rate of objects spawning
         // public float waterSpawnRate = 0.005f;
 
-        
+        public static float Water;
 
         [Range(0f, 1f)]
-        public float WaterThreshold;
+        public float WaterThreshold = 0.45f;
         
         [HideInInspector]
         public bool RandomNoiseSeed;
@@ -61,6 +61,7 @@ namespace Ecosystem.Grid
 
         void Awake() 
         {
+            Water = WaterThreshold;
             InitObjects();
             RandomizeStartGrid();
             CheckCorners();
@@ -86,11 +87,6 @@ namespace Ecosystem.Grid
             grid = new GridData(tiles.GetLength(0), tiles.GetLength(1));
             worldGridSystem = World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<WorldGridSystem>();
             worldGridSystem.InitGrid(grid);
-        }
-
-        private List<Vector2> GeneratePoisson()
-        {
-            throw new NotImplementedException();
         }
 
         private void RandomizeStartGrid()

--- a/Assets/Scripts/Grid/GameZone.cs
+++ b/Assets/Scripts/Grid/GameZone.cs
@@ -49,12 +49,6 @@ namespace Ecosystem.Grid
         public  float Persistence;
         public float Lacunarity;
 
-        [Header("Poisson Disc Sampling")]
-        [Range(0.1f, 10f)]
-        public float min_radius;
-        [Range(0.1f, 10f)]
-        public float max_radius;
-
         private GridData grid;
         private WorldGridSystem worldGridSystem;
 

--- a/Assets/Scripts/Grid/GameZone.cs
+++ b/Assets/Scripts/Grid/GameZone.cs
@@ -98,13 +98,12 @@ namespace Ecosystem.Grid
             System.Random random = new System.Random();
             
             int seed = RandomNoiseSeed ? random.Next() : NoiseSeed;
-            float[,] noiseMap = Noise.GenerateNoiseMap(tiles.GetLength(0), tiles.GetLength(1), seed, Scale, Octaves, Persistence, Lacunarity);
-            NoiseMap = noiseMap;
+            NoiseMap = Noise.GenerateNoiseMap(tiles.GetLength(0), tiles.GetLength(1), seed, Scale, Octaves, Persistence, Lacunarity);
             for (int y = 0; y < tiles.GetLength(1); y++ )
             {
                 for (int x = 0; x < tiles.GetLength(0); x++ )
                 {
-                    tiles[x,y] = noiseMap[x,y] > WaterThreshold ? landIndex : waterIndex;
+                    tiles[x,y] = NoiseMap[x,y] > WaterThreshold ? landIndex : waterIndex;
                 }
             }
         }

--- a/Assets/Scripts/Grid/GameZone.cs
+++ b/Assets/Scripts/Grid/GameZone.cs
@@ -16,6 +16,7 @@ namespace Ecosystem.Grid
         
         public static Tilemap tilemap;
         public static List<Vector3Int> tilePositions;
+        public static float[,] NoiseMap;
 
         private TilesAssetsToTilemap tilesAssetsToTilemap;
 
@@ -47,6 +48,12 @@ namespace Ecosystem.Grid
         [Range(0f, 1f)] 
         public  float Persistence;
         public float Lacunarity;
+
+        [Header("Poisson Disc Sampling")]
+        [Range(0.1f, 10f)]
+        public float min_radius;
+        [Range(0.1f, 10f)]
+        public float max_radius;
 
         private GridData grid;
         private WorldGridSystem worldGridSystem;
@@ -87,12 +94,18 @@ namespace Ecosystem.Grid
             worldGridSystem.InitGrid(grid);
         }
 
+        private List<Vector2> GeneratePoisson()
+        {
+            throw new NotImplementedException();
+        }
+
         private void RandomizeStartGrid()
         {
             System.Random random = new System.Random();
             
             int seed = RandomNoiseSeed ? random.Next() : NoiseSeed;
             float[,] noiseMap = Noise.GenerateNoiseMap(tiles.GetLength(0), tiles.GetLength(1), seed, Scale, Octaves, Persistence, Lacunarity);
+            NoiseMap = noiseMap;
             for (int y = 0; y < tiles.GetLength(1); y++ )
             {
                 for (int x = 0; x < tiles.GetLength(0); x++ )

--- a/Assets/Scripts/Grid/PoissonDiscSampling.cs
+++ b/Assets/Scripts/Grid/PoissonDiscSampling.cs
@@ -28,8 +28,9 @@ namespace Ecosystem.Grid
                 int x = (int)spawnCentre.x;
                 int y = (int)spawnCentre.y;
                 grey = noiseMap[x, y];
-                //grey = Mathf.Clamp(grey, 0.0f, 1.0f);
+                grey = Mathf.Clamp(grey, 0.0f, 1.0f);
                 float min_dist = min_radius + grey * (max_radius - min_radius);
+                min_dist = Mathf.Clamp(min_dist, min_radius, max_radius);
                 float radius = min_dist * (Random.value + 1.0f);
                 bool candidateAccepted = false;
                 for(int i = 0; i < numSamplesBeforeRejection; i++)

--- a/Assets/Scripts/Grid/PoissonDiscSampling.cs
+++ b/Assets/Scripts/Grid/PoissonDiscSampling.cs
@@ -5,7 +5,7 @@ namespace Ecosystem.Grid
 {
     public static class PoissonDiscSampling
     {
-        public static List<Vector2> GeneratePoisson(float radius, Vector2 sampleRegionSize, int numSamplesBeforeRejection = 30)
+        public static List<Vector2> GeneratePoisson(float radius, Vector2 sampleRegionSize, int numSamplesBeforeRejection)
         {
             float cellSize = radius / Mathf.Sqrt(2);
 

--- a/Assets/Scripts/Grid/PoissonDiscSampling.cs
+++ b/Assets/Scripts/Grid/PoissonDiscSampling.cs
@@ -8,6 +8,12 @@ namespace Ecosystem.Grid
         public static List<Vector2> GeneratePoisson(float[,] noiseMap, Vector2 sampleRegionSize, int numSamplesBeforeRejection, float min_radius, float max_radius)
         {
             float grey;
+            if(min_radius > max_radius)
+            {
+                var tmp = max_radius;
+                max_radius = min_radius;
+                min_radius = tmp;
+            }
             float cellSize = max_radius / Mathf.Sqrt(2);
 
             int[,] grid = new int[Mathf.CeilToInt(sampleRegionSize.x / cellSize), Mathf.CeilToInt(sampleRegionSize.y / cellSize)];
@@ -23,7 +29,8 @@ namespace Ecosystem.Grid
                 int y = (int)spawnCentre.y;
                 grey = noiseMap[(int)x, (int)y];
                 Mathf.Clamp(grey, 0.0f, 1.0f);
-                float radius = min_radius + grey * (max_radius - min_radius);
+                float min_dist = min_radius + grey * (max_radius - min_radius);
+                float radius = min_dist * (Random.value + 1.0f);
                 bool candidateAccepted = false;
                 for(int i = 0; i < numSamplesBeforeRejection; i++)
                 {

--- a/Assets/Scripts/Grid/PoissonDiscSampling.cs
+++ b/Assets/Scripts/Grid/PoissonDiscSampling.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Ecosystem.Grid
+{
+    public static class PoissonDiscSampling
+    {
+        public static List<Vector2> GeneratePoisson(float radius, Vector2 sampleRegionSize, int numSamplesBeforeRejection = 30)
+        {
+            float cellSize = radius / Mathf.Sqrt(2);
+
+            int[,] grid = new int[Mathf.CeilToInt(sampleRegionSize.x / cellSize), Mathf.CeilToInt(sampleRegionSize.y / cellSize)];
+            List<Vector2> points = new List<Vector2>();
+            List<Vector2> spawnPoints = new List<Vector2>();
+
+            spawnPoints.Add(sampleRegionSize / 2);
+            while (spawnPoints.Count > 0)
+            {
+                int spawnIndex = Random.Range(0, spawnPoints.Count);
+                Vector2 spawnCentre = spawnPoints[spawnIndex];
+                bool candidateAccepted = false;
+                for(int i = 0; i < numSamplesBeforeRejection; i++)
+                {
+                    float angle = Random.value * Mathf.PI * 2;
+                    Vector2 dir = new Vector2(Mathf.Sin(angle), Mathf.Cos(angle));
+                    Vector2 candidate = spawnCentre + dir * Random.Range(radius, 2 * radius);
+                    if (isValid(candidate,sampleRegionSize,cellSize,radius,points,grid))
+                    {
+                        points.Add(candidate);
+                        spawnPoints.Add(candidate);
+                        grid[(int)(candidate.x / cellSize), (int)(candidate.y / cellSize)] = points.Count;
+                        candidateAccepted = true;
+                        break;
+                    }
+                }
+                if (!candidateAccepted)
+                {
+                    spawnPoints.RemoveAt(spawnIndex);
+                }
+            }
+            return points;
+        }
+
+        static bool isValid(Vector2 candidate, Vector2 sampleRegionSize, float cellSize, float radius, List<Vector2> points, int[,] grid)
+        {
+            if(candidate.x >= 0 && candidate.x < sampleRegionSize.x && candidate.y >= 0 && candidate.y < sampleRegionSize.y)
+            {
+                int cellX = (int)(candidate.x / cellSize);
+                int cellY = (int)(candidate.y / cellSize);
+                int searchStartX = Mathf.Max(0, cellX - 2);
+                int searchEndX = Mathf.Min(cellX + 2, grid.GetLength(0) - 1);
+                int searchStartY = Mathf.Max(0, cellY - 2);
+                int searchEndY = Mathf.Min(cellY + 2, grid.GetLength(1) - 1);
+
+                for(int x = searchStartX; x <= searchEndX; x++)
+                {
+                    for(int y = searchStartY; y <= searchEndY; y++)
+                    {
+                        int pointIndex = grid[x, y] - 1;
+                        if(pointIndex != -1)
+                        {
+                            float sqrDst = (candidate - points[pointIndex]).sqrMagnitude;
+                            if(sqrDst < radius*radius)
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Grid/PoissonDiscSampling.cs
+++ b/Assets/Scripts/Grid/PoissonDiscSampling.cs
@@ -27,8 +27,8 @@ namespace Ecosystem.Grid
                 Vector2 spawnCentre = spawnPoints[spawnIndex];
                 int x = (int)spawnCentre.x;
                 int y = (int)spawnCentre.y;
-                grey = noiseMap[(int)x, (int)y];
-                Mathf.Clamp(grey, 0.0f, 1.0f);
+                grey = noiseMap[x, y];
+                //grey = Mathf.Clamp(grey, 0.0f, 1.0f);
                 float min_dist = min_radius + grey * (max_radius - min_radius);
                 float radius = min_dist * (Random.value + 1.0f);
                 bool candidateAccepted = false;

--- a/Assets/Scripts/Grid/PoissonDiscSampling.cs
+++ b/Assets/Scripts/Grid/PoissonDiscSampling.cs
@@ -5,7 +5,7 @@ namespace Ecosystem.Grid
 {
     public static class PoissonDiscSampling
     {
-        public static List<Vector2> GeneratePoisson(float[,] noiseMap, Vector2 sampleRegionSize, int numSamplesBeforeRejection, float min_radius, float max_radius)
+        public static List<Vector2> GeneratePoisson(float[,] noiseMap, Vector2 sampleRegionSize, int numSamplesBeforeRejection, float min_radius, float max_radius, int numToSpawn, float waterTreshold)
         {
             float grey;
             if(min_radius > max_radius)
@@ -19,31 +19,42 @@ namespace Ecosystem.Grid
             int[,] grid = new int[Mathf.CeilToInt(sampleRegionSize.x / cellSize), Mathf.CeilToInt(sampleRegionSize.y / cellSize)];
             List<Vector2> points = new List<Vector2>();
             List<Vector2> spawnPoints = new List<Vector2>();
+            int toSpawnRemaining = numToSpawn;
 
             spawnPoints.Add(sampleRegionSize / 2);
             while (spawnPoints.Count > 0)
             {
+                if(toSpawnRemaining <= 0)
+                {
+                    break;
+                }
                 int spawnIndex = Random.Range(0, spawnPoints.Count);
                 Vector2 spawnCentre = spawnPoints[spawnIndex];
                 int x = (int)spawnCentre.x;
                 int y = (int)spawnCentre.y;
                 grey = noiseMap[x, y];
+                /*if (grey <= waterTreshold)
+                {
+                    spawnPoints.RemoveAt(spawnIndex);
+                    continue;
+                }*/
                 grey = Mathf.Clamp(grey, 0.0f, 1.0f);
                 float min_dist = min_radius + grey * (max_radius - min_radius);
                 min_dist = Mathf.Clamp(min_dist, min_radius, max_radius);
                 float radius = min_dist * (Random.value + 1.0f);
                 bool candidateAccepted = false;
-                for(int i = 0; i < numSamplesBeforeRejection; i++)
+                for (int i = 0; i < numSamplesBeforeRejection; i++)
                 {
                     float angle = Random.value * Mathf.PI * 2;
                     Vector2 dir = new Vector2(Mathf.Sin(angle), Mathf.Cos(angle));
                     Vector2 candidate = spawnCentre + dir * Random.Range(radius, 2 * radius);
-                    if (isValid(candidate,sampleRegionSize,cellSize,radius,points,grid))
+                    if (isValid(candidate, sampleRegionSize, cellSize, radius, points, grid))
                     {
                         points.Add(candidate);
                         spawnPoints.Add(candidate);
                         grid[(int)(candidate.x / cellSize), (int)(candidate.y / cellSize)] = points.Count;
                         candidateAccepted = true;
+                        toSpawnRemaining--;
                         break;
                     }
                 }

--- a/Assets/Scripts/Grid/PoissonDiscSampling.cs
+++ b/Assets/Scripts/Grid/PoissonDiscSampling.cs
@@ -5,9 +5,10 @@ namespace Ecosystem.Grid
 {
     public static class PoissonDiscSampling
     {
-        public static List<Vector2> GeneratePoisson(float radius, Vector2 sampleRegionSize, int numSamplesBeforeRejection)
+        public static List<Vector2> GeneratePoisson(float[,] noiseMap, Vector2 sampleRegionSize, int numSamplesBeforeRejection, float min_radius, float max_radius)
         {
-            float cellSize = radius / Mathf.Sqrt(2);
+            float grey;
+            float cellSize = max_radius / Mathf.Sqrt(2);
 
             int[,] grid = new int[Mathf.CeilToInt(sampleRegionSize.x / cellSize), Mathf.CeilToInt(sampleRegionSize.y / cellSize)];
             List<Vector2> points = new List<Vector2>();
@@ -18,6 +19,11 @@ namespace Ecosystem.Grid
             {
                 int spawnIndex = Random.Range(0, spawnPoints.Count);
                 Vector2 spawnCentre = spawnPoints[spawnIndex];
+                int x = (int)spawnCentre.x;
+                int y = (int)spawnCentre.y;
+                grey = noiseMap[(int)x, (int)y];
+                Mathf.Clamp(grey, 0.0f, 1.0f);
+                float radius = min_radius + grey * (max_radius - min_radius);
                 bool candidateAccepted = false;
                 for(int i = 0; i < numSamplesBeforeRejection; i++)
                 {

--- a/Assets/Scripts/Grid/PoissonDiscSampling.cs.meta
+++ b/Assets/Scripts/Grid/PoissonDiscSampling.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19105005ba0956848af1c41986b49e24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Grid/ScenaryToTilemap.cs
+++ b/Assets/Scripts/Grid/ScenaryToTilemap.cs
@@ -10,6 +10,10 @@ namespace Ecosystem.Grid
         //Matrix with all GameObjects in the Grid
         private Scenary [,] gameObjectsInGrid;
         private int [,] tiles;
+        private List<Vector2> poissonPoints;
+
+        private int waterIndex = 17;
+        private int landIndex = 34;
 
         public float greenScenaryNeigbourRate = 0.15f;
         public float greenScenarySpawnRate = 0.05f;
@@ -26,6 +30,7 @@ namespace Ecosystem.Grid
         void Start()
         {
             this.tiles = GameZone.tiles;
+            this.poissonPoints = PoissonDiscSampling.GeneratePoisson(1, new Vector2(tiles.GetLength(0), tiles.GetLength(1)), 10);
 
             gameObjectsInGrid = new Scenary [tiles.GetLength(0), tiles.GetLength(1)];
             CreateEmptyScenary();
@@ -34,6 +39,31 @@ namespace Ecosystem.Grid
 
         private void SetupGameObjects()
         {
+            if (poissonPoints != null)
+            {
+                foreach(Vector2 point in poissonPoints)
+                {
+                    int row = (int)point.x;
+                    int col = (int)point.y;
+                    if (tiles[row, col] == 34)
+                    {
+                        //Scenary in the desert does not spawn more often if there are other things closeby
+                        gameObjectsInGrid[row, col] = RandomizeDesertScenary(desertScenarySpawnRate, row, col);
+                    }
+                    else if (tiles[row, col] == 51)
+                    {
+                        if (ScenaryAsNeighbour(row, col) != Scenary.Empty)
+                        {
+                            gameObjectsInGrid[row, col] = RandomizeGreenScenary(greenScenaryNeigbourRate, row, col);
+                        }
+                        else
+                        {
+                            gameObjectsInGrid[row, col] = RandomizeGreenScenary(greenScenarySpawnRate, row, col);
+                        }
+                    }
+                }
+            }
+            /*
             for (int row = 0; row < tiles.GetLength(0); row++)
             {
                 for (int col = 0; col < tiles.GetLength(1); col++)
@@ -55,7 +85,7 @@ namespace Ecosystem.Grid
                         }
                     }
                 }
-            }
+            }*/
         }
 
         private Scenary ScenaryAsNeighbour(int row, int col)

--- a/Assets/Scripts/Grid/ScenaryToTilemap.cs
+++ b/Assets/Scripts/Grid/ScenaryToTilemap.cs
@@ -13,10 +13,12 @@ namespace Ecosystem.Grid
         private List<Vector2> poissonPoints;
 
         [Header("Poisson Disc Sampling")]
-        [Range(1.0f, 10f)]
+        [Range(0.1f, 5f)]
         public float min_radius;
-        [Range(1.0f, 10f)]
+        [Range(0.1f, 5f)]
         public float max_radius;
+        [Range(1, 50)]
+        public int numSamplesBeforeRejection = 20;
 
 
         private int waterIndex = 17;
@@ -37,7 +39,7 @@ namespace Ecosystem.Grid
         void Start()
         {
             this.tiles = GameZone.tiles;
-            this.poissonPoints = PoissonDiscSampling.GeneratePoisson(GameZone.NoiseMap, new Vector2(tiles.GetLength(0), tiles.GetLength(1)), 10, min_radius, max_radius);
+            this.poissonPoints = PoissonDiscSampling.GeneratePoisson(GameZone.NoiseMap, new Vector2(tiles.GetLength(0), tiles.GetLength(1)), numSamplesBeforeRejection, min_radius, max_radius);
 
             gameObjectsInGrid = new Scenary [tiles.GetLength(0), tiles.GetLength(1)];
             CreateEmptyScenary();

--- a/Assets/Scripts/Grid/ScenaryToTilemap.cs
+++ b/Assets/Scripts/Grid/ScenaryToTilemap.cs
@@ -12,6 +12,13 @@ namespace Ecosystem.Grid
         private int [,] tiles;
         private List<Vector2> poissonPoints;
 
+        [Header("Poisson Disc Sampling")]
+        [Range(0.1f, 10f)]
+        public float min_radius;
+        [Range(0.1f, 10f)]
+        public float max_radius;
+
+
         private int waterIndex = 17;
         private int landIndex = 34;
 
@@ -30,7 +37,7 @@ namespace Ecosystem.Grid
         void Start()
         {
             this.tiles = GameZone.tiles;
-            this.poissonPoints = PoissonDiscSampling.GeneratePoisson(1, new Vector2(tiles.GetLength(0), tiles.GetLength(1)), 10);
+            this.poissonPoints = PoissonDiscSampling.GeneratePoisson(GameZone.NoiseMap, new Vector2(tiles.GetLength(0), tiles.GetLength(1)), 10, min_radius, max_radius);
 
             gameObjectsInGrid = new Scenary [tiles.GetLength(0), tiles.GetLength(1)];
             CreateEmptyScenary();
@@ -39,7 +46,7 @@ namespace Ecosystem.Grid
 
         private void SetupGameObjects()
         {
-            if (poissonPoints != null)
+           if (poissonPoints != null)
             {
                 foreach(Vector2 point in poissonPoints)
                 {
@@ -63,8 +70,8 @@ namespace Ecosystem.Grid
                     }
                 }
             }
-            /*
-            for (int row = 0; row < tiles.GetLength(0); row++)
+            
+            /*for (int row = 0; row < tiles.GetLength(0); row++)
             {
                 for (int col = 0; col < tiles.GetLength(1); col++)
                 {

--- a/Assets/Scripts/Grid/ScenaryToTilemap.cs
+++ b/Assets/Scripts/Grid/ScenaryToTilemap.cs
@@ -13,9 +13,9 @@ namespace Ecosystem.Grid
         private List<Vector2> poissonPoints;
 
         [Header("Poisson Disc Sampling")]
-        [Range(0.1f, 10f)]
+        [Range(1.0f, 10f)]
         public float min_radius;
-        [Range(0.1f, 10f)]
+        [Range(1.0f, 10f)]
         public float max_radius;
 
 

--- a/Assets/Scripts/Grid/ScenaryToTilemap.cs
+++ b/Assets/Scripts/Grid/ScenaryToTilemap.cs
@@ -58,7 +58,9 @@ namespace Ecosystem.Grid
                     else if (tiles[row, col] == 51)
                     {
 
-                        gameObjectsInGrid[row, col] = SpawnRandomTree(row, col);
+                        //gameObjectsInGrid[row, col] = SpawnRandomTree(row, col);
+                        gameObjectsInGrid[row, col] = RandomizeGreenScenary(1, row, col);
+                        
                         /*if (ScenaryAsNeighbour(row, col) != Scenary.Empty)
                         {
                             gameObjectsInGrid[row, col] = RandomizeGreenScenary(greenScenaryNeigbourRate, row, col);

--- a/Assets/Scripts/Grid/ScenaryToTilemap.cs
+++ b/Assets/Scripts/Grid/ScenaryToTilemap.cs
@@ -13,16 +13,12 @@ namespace Ecosystem.Grid
         private List<Vector2> poissonPoints;
 
         [Header("Poisson Disc Sampling")]
-        [Range(0.1f, 5f)]
+        [Range(1f, 15f)]
         public float min_radius;
-        [Range(0.1f, 5f)]
+        [Range(1f, 15f)]
         public float max_radius;
         [Range(1, 50)]
         public int numSamplesBeforeRejection = 20;
-
-
-        private int waterIndex = 17;
-        private int landIndex = 34;
 
         public float greenScenaryNeigbourRate = 0.15f;
         public float greenScenarySpawnRate = 0.05f;
@@ -61,14 +57,16 @@ namespace Ecosystem.Grid
                     }
                     else if (tiles[row, col] == 51)
                     {
-                        if (ScenaryAsNeighbour(row, col) != Scenary.Empty)
+
+                        gameObjectsInGrid[row, col] = SpawnRandomTree(row, col);
+                        /*if (ScenaryAsNeighbour(row, col) != Scenary.Empty)
                         {
                             gameObjectsInGrid[row, col] = RandomizeGreenScenary(greenScenaryNeigbourRate, row, col);
                         }
                         else
                         {
                             gameObjectsInGrid[row, col] = RandomizeGreenScenary(greenScenarySpawnRate, row, col);
-                        }
+                        }*/
                     }
                 }
             }
@@ -130,6 +128,13 @@ namespace Ecosystem.Grid
         private Quaternion RandomQuaternion()
         {
             return Quaternion.Euler(0f, Random.Range(0f, 360f), 0f);
+        }
+
+        private Scenary SpawnRandomTree(int row, int col)
+        {
+            Vector3 spawnPos = gameZone.GetWorldPosition(row, col);
+            Instantiate(GetRandomTree(), spawnPos, RandomQuaternion());
+            return Scenary.Tree;
         }
 
         private Scenary RandomizeGreenScenary(float value, int row, int col)

--- a/Assets/Scripts/Grid/ScenaryToTilemap.cs
+++ b/Assets/Scripts/Grid/ScenaryToTilemap.cs
@@ -13,12 +13,13 @@ namespace Ecosystem.Grid
         private List<Vector2> poissonPoints;
 
         [Header("Poisson Disc Sampling")]
-        [Range(1f, 15f)]
+        [Range(0.1f, 15f)]
         public float min_radius;
         [Range(1f, 15f)]
         public float max_radius;
         [Range(1, 50)]
         public int numSamplesBeforeRejection = 20;
+        public int numToSpawn;
 
         public float greenScenaryNeigbourRate = 0.15f;
         public float greenScenarySpawnRate = 0.05f;
@@ -35,7 +36,13 @@ namespace Ecosystem.Grid
         void Start()
         {
             this.tiles = GameZone.tiles;
-            this.poissonPoints = PoissonDiscSampling.GeneratePoisson(GameZone.NoiseMap, new Vector2(tiles.GetLength(0), tiles.GetLength(1)), numSamplesBeforeRejection, min_radius, max_radius);
+            this.poissonPoints = PoissonDiscSampling.GeneratePoisson(GameZone.NoiseMap,
+                                                                     new Vector2(tiles.GetLength(0), tiles.GetLength(1)),
+                                                                     numSamplesBeforeRejection,
+                                                                     min_radius,
+                                                                     max_radius,
+                                                                     numToSpawn,
+                                                                     GameZone.Water);
 
             gameObjectsInGrid = new Scenary [tiles.GetLength(0), tiles.GetLength(1)];
             CreateEmptyScenary();

--- a/Assets/Scripts/Grid/ScenaryToTilemap.cs
+++ b/Assets/Scripts/Grid/ScenaryToTilemap.cs
@@ -52,23 +52,11 @@ namespace Ecosystem.Grid
                     int col = (int)point.y;
                     if (tiles[row, col] == 34)
                     {
-                        //Scenary in the desert does not spawn more often if there are other things closeby
-                        gameObjectsInGrid[row, col] = RandomizeDesertScenary(desertScenarySpawnRate, row, col);
+                        gameObjectsInGrid[row, col] = RandomizeDesertScenary(1, row, col);
                     }
                     else if (tiles[row, col] == 51)
                     {
-
-                        //gameObjectsInGrid[row, col] = SpawnRandomTree(row, col);
                         gameObjectsInGrid[row, col] = RandomizeGreenScenary(1, row, col);
-                        
-                        /*if (ScenaryAsNeighbour(row, col) != Scenary.Empty)
-                        {
-                            gameObjectsInGrid[row, col] = RandomizeGreenScenary(greenScenaryNeigbourRate, row, col);
-                        }
-                        else
-                        {
-                            gameObjectsInGrid[row, col] = RandomizeGreenScenary(greenScenarySpawnRate, row, col);
-                        }*/
                     }
                 }
             }


### PR DESCRIPTION
Uses Poisson disc sampling for object placement. The algorithm uses perlin noise to decide the minimum distance between the objects. 