### PR TITLE
Fix animator updating before entity conversion

### DIFF
--- a/Assets/Prefabs/Animals/Eagle.prefab
+++ b/Assets/Prefabs/Animals/Eagle.prefab
@@ -1192,6 +1192,11 @@ PrefabInstance:
       propertyPath: Urge
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 3352532566447112004, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: animator
+      value: 
+      objectReference: {fileID: 5939344901363283709}
     - target: {fileID: 4006984848664019944, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Prefabs/Animals/Fox.prefab
+++ b/Assets/Prefabs/Animals/Fox.prefab
@@ -39,6 +39,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3352532566447112004, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: animator
+      value: 
+      objectReference: {fileID: 108122444459103273}
     - target: {fileID: 5070148452478974442, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Animals/Rabbit.prefab
+++ b/Assets/Prefabs/Animals/Rabbit.prefab
@@ -96,6 +96,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3352532566447112004, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: animator
+      value: 
+      objectReference: {fileID: 2207735872511650099}
     - target: {fileID: 5070148452478974442, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Animals/Sardine.prefab
+++ b/Assets/Prefabs/Animals/Sardine.prefab
@@ -1268,6 +1268,11 @@ PrefabInstance:
       propertyPath: Urge
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 3352532566447112004, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: animator
+      value: 
+      objectReference: {fileID: 8110904167012176384}
     - target: {fileID: 4006984848664019944, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scripts/Animation/EntityAnimation.cs
+++ b/Assets/Scripts/Animation/EntityAnimation.cs
@@ -14,7 +14,7 @@ namespace Ecosystem.Animation {
             animator = GetComponent<Animator>();
         }
 
-        void Update() {
+        public void UpdateState() {
             if (math.length(movement.GetMovementInput()) != 0) {
                 RunAnimation();
             } else {

--- a/Assets/Scripts/Attributes/Animal.cs
+++ b/Assets/Scripts/Attributes/Animal.cs
@@ -3,6 +3,7 @@ using Ecosystem.StateMachines;
 using Ecosystem.ECS.Hybrid;
 using Ecosystem.ECS.Animal;
 using Ecosystem.Genetics;
+using Ecosystem.Animation;
 
 namespace Ecosystem.Attributes
 {
@@ -15,6 +16,10 @@ namespace Ecosystem.Attributes
         public float MatingLimit {get; private set;}
         public float BraveryLevel { get; private set;}
 
+        [SerializeField]
+        private EntityAnimation animator = default;
+
+        [Header("Hybrid Entity")]
         [SerializeField]
         private AnimalDNAAuthoring animalDNAAuthoring = default;
         [SerializeField]
@@ -39,6 +44,7 @@ namespace Ecosystem.Attributes
 
         private void Awake() {
             this.stateMachine = new StateMachine();
+            animator = GetComponent<EntityAnimation>();
 
             hybridEntity.Converted += Init;
         }
@@ -146,6 +152,8 @@ namespace Ecosystem.Attributes
                 ChangeState(this.casualState);
             }
             stateMachine.Update();
+
+            animator?.UpdateState();
         }
 
         private float DiffLength(Vector3 target) 


### PR DESCRIPTION
EntityAnimation tried to use hybrid components before the entity conversion. Now it gets updated manually at the end of the Animal update loop which already has the correct execution order.