### PR TITLE
Fix missing changes after merge

### DIFF
--- a/Assets/Prefabs/Animals/Animal.prefab
+++ b/Assets/Prefabs/Animals/Animal.prefab
@@ -46,6 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 916414920c3d445d995b24e819088e68, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  animator: {fileID: 0}
   animalDNAAuthoring: {fileID: 9054965001546035335}
   hybridEntity: {fileID: 205040342004547871}
   movement: {fileID: 5070148453820763526}
@@ -395,6 +396,45 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Value: 0.5
+--- !u!114 &5075381746476165254
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5070148453820763646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5aaa9fa491a454ecf8be8fb0a6dde989, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MaxHunger: 3
+--- !u!114 &6303536544478638138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5070148453820763646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a8bce6621d13430ab3239285eaa0873, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MaxThirst: 3
+--- !u!114 &4555329424664434073
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5070148453820763646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 186afd44aa07c06409a171bf47f440dd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MaxUrge: 3
 --- !u!114 &9054965001546035335
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -471,12 +511,12 @@ MonoBehaviour:
   m_ShapeType: 1
   m_PrimitiveCenter:
     x: 0
-    y: 1
+    y: 0.2
     z: 0
   m_PrimitiveSize:
-    x: 1
-    y: 1
-    z: 2
+    x: 0.2
+    y: 0.2
+    z: 0.4
   m_PrimitiveOrientation:
     Value:
       x: 270
@@ -484,15 +524,15 @@ MonoBehaviour:
       z: 0
     RotationOrder: 4
   m_Capsule:
-    Height: 2
-    Radius: 0.5
+    Height: 0.4
+    Radius: 0.1
     Axis: 2
   m_Cylinder:
-    Height: 2
-    Radius: 0.5
+    Height: 0.4
+    Radius: 0.1
     Axis: 2
   m_CylinderSideCount: 20
-  m_SphereRadius: 1
+  m_SphereRadius: 0.2
   m_MinimumSkinnedVertexWeight: 0.1
   m_ConvexHullGenerationParameters:
     m_SimplificationTolerance: 0.015
@@ -616,19 +656,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animal: {fileID: 3352532566447112004}
---- !u!114 &5075381746476165254
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5070148453820763646}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5aaa9fa491a454ecf8be8fb0a6dde989, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  MaxHunger: 3
 --- !u!114 &650131295108155739
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -643,32 +670,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Lifespan: 10
   Age: 0
---- !u!114 &6303536544478638138
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5070148453820763646}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2a8bce6621d13430ab3239285eaa0873, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  MaxThirst: 3
---- !u!114 &4555329424664434073
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5070148453820763646}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 186afd44aa07c06409a171bf47f440dd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  MaxUrge: 3
 --- !u!114 &8358889571667046334
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Animals/Eagle.prefab
+++ b/Assets/Prefabs/Animals/Eagle.prefab
@@ -1316,22 +1316,27 @@ PrefabInstance:
     - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: m_PrimitiveSize.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
-        type: 3}
-      propertyPath: m_Capsule.Height
-      value: 1
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: m_Cylinder.Height
-      value: 1
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: m_SphereRadius
-      value: 0.5
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveCenter.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Capsule.Height
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 5075381746476165254, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
@@ -1390,6 +1395,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1ab49e1f0a45e6143b303a5638864304, type: 3}
+--- !u!1 &4564373161721369777 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5070148452478974443, guid: 1ab49e1f0a45e6143b303a5638864304,
+    type: 3}
+  m_PrefabInstance: {fileID: 8722100367199563098}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4564373163055538396 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5070148453820763526, guid: 1ab49e1f0a45e6143b303a5638864304,
@@ -1411,12 +1422,6 @@ GameObject:
 --- !u!4 &4564373161721369776 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5070148452478974442, guid: 1ab49e1f0a45e6143b303a5638864304,
-    type: 3}
-  m_PrefabInstance: {fileID: 8722100367199563098}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &4564373161721369777 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5070148452478974443, guid: 1ab49e1f0a45e6143b303a5638864304,
     type: 3}
   m_PrefabInstance: {fileID: 8722100367199563098}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Animals/Fox.prefab
+++ b/Assets/Prefabs/Animals/Fox.prefab
@@ -258,9 +258,17 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1435295048096349928}
     m_Modifications:
+    - target: {fileID: 1149708331590140, guid: 4a9270e81fdd4874a91f7acb2ea9e373, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1541523258012542, guid: 4a9270e81fdd4874a91f7acb2ea9e373, type: 3}
       propertyPath: m_Name
       value: Fox Default
+      objectReference: {fileID: 0}
+    - target: {fileID: 1736618986494394, guid: 4a9270e81fdd4874a91f7acb2ea9e373, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4401049854040582, guid: 4a9270e81fdd4874a91f7acb2ea9e373, type: 3}
       propertyPath: m_LocalPosition.x
@@ -311,25 +319,50 @@ PrefabInstance:
       propertyPath: m_Material
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 135949954064942100, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 136053785128579586, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
         type: 3}
       propertyPath: m_Material
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 136053785128579586, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 136213194282202612, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
         type: 3}
       propertyPath: m_Material
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 136213194282202612, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 136727415921694736, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
+        type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 136727415921694736, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 136768188992667682, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
         type: 3}
       propertyPath: m_Material
       value: 
       objectReference: {fileID: 0}
     - target: {fileID: 136768188992667682, guid: 4a9270e81fdd4874a91f7acb2ea9e373,
         type: 3}
-      propertyPath: m_Material
-      value: 
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4a9270e81fdd4874a91f7acb2ea9e373, type: 3}

--- a/Assets/Prefabs/Animals/Fox.prefab
+++ b/Assets/Prefabs/Animals/Fox.prefab
@@ -160,6 +160,51 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 54ebd0d0cdfca8d48be3c648fec0bb90,
         type: 2}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.z
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Capsule.Height
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Cylinder.Height
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_SphereRadius
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveCenter.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.x
+      value: 0.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.y
+      value: 0.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Capsule.Radius
+      value: 0.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Cylinder.Radius
+      value: 0.12
+      objectReference: {fileID: 0}
     - target: {fileID: 5075381746476165254, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: MaxHunger

--- a/Assets/Prefabs/Animals/Rabbit.prefab
+++ b/Assets/Prefabs/Animals/Rabbit.prefab
@@ -197,6 +197,36 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: bdd7a7559f0396f4f86fb7ae5a3d8b3d,
         type: 2}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.z
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Cylinder.Height
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_SphereRadius
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Cylinder.Radius
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 5075381746476165254, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: MaxHunger

--- a/Assets/Prefabs/Animals/Sardine.prefab
+++ b/Assets/Prefabs/Animals/Sardine.prefab
@@ -1384,6 +1384,51 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: a1b52950926274649b65d081f535a333,
         type: 2}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.z
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Capsule.Height
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Cylinder.Height
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_SphereRadius
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveCenter.y
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_PrimitiveSize.y
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Capsule.Radius
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5070148453820763524, guid: 1ab49e1f0a45e6143b303a5638864304,
+        type: 3}
+      propertyPath: m_Cylinder.Radius
+      value: 0.05
+      objectReference: {fileID: 0}
     - target: {fileID: 5075381746476165254, guid: 1ab49e1f0a45e6143b303a5638864304,
         type: 3}
       propertyPath: MaxHunger
@@ -1426,6 +1471,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1ab49e1f0a45e6143b303a5638864304, type: 3}
+--- !u!1 &2003170221973116033 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5070148452478974443, guid: 1ab49e1f0a45e6143b303a5638864304,
+    type: 3}
+  m_PrefabInstance: {fileID: 6742022317625863530}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2003170222783324396 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5070148453820763526, guid: 1ab49e1f0a45e6143b303a5638864304,
@@ -1441,12 +1492,6 @@ MonoBehaviour:
 --- !u!4 &2003170221973116032 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5070148452478974442, guid: 1ab49e1f0a45e6143b303a5638864304,
-    type: 3}
-  m_PrefabInstance: {fileID: 6742022317625863530}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2003170221973116033 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5070148452478974443, guid: 1ab49e1f0a45e6143b303a5638864304,
     type: 3}
   m_PrefabInstance: {fileID: 6742022317625863530}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/GameZone.prefab
+++ b/Assets/Prefabs/GameZone.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1022454915255237109}
   - component: {fileID: 1022454915255237108}
   - component: {fileID: -7102660320631865697}
+  - component: {fileID: 5188475410913618776}
   m_Layer: 0
   m_Name: GameZone
   m_TagString: Untagged
@@ -45,8 +46,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bdc8923cb5cade64cb4073cd79a5a11c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  waterNeighbourRate: 0.65
-  waterSpawnRate: 0.005
+  mapMode: 0
+  RandomNoiseSeed: 0
+  NoiseSeed: 0
+  Scale: 0
+  Octaves: 0
+  Persistence: 0
+  Lacunarity: 1
+  heightMultiplier: 5
+  Regions: []
+  WaterThresholdIndex: 0
 --- !u!114 &-7102660320631865697
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -60,6 +69,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameZone: {fileID: 1022454915255237108}
+  min_radius: 0
+  max_radius: 0
+  numSamplesBeforeRejection: 20
+  numToSpawn: 0
   greenScenaryNeigbourRate: 0.15
   greenScenarySpawnRate: 0.05
   desertScenarySpawnRate: 0.1
@@ -115,6 +128,21 @@ MonoBehaviour:
   - {fileID: 4678081621971413900, guid: 0db75333ec2227f469a31a3c16d01153, type: 3}
   cacti:
   - {fileID: 4164056731790697608, guid: b7b5424cac5ceed42a08b8fcce75fe11, type: 3}
+--- !u!114 &5188475410913618776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1022454915255237003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cab5d5547a2e85978e7451faba7841c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TextureRenderer: {fileID: 0}
+  meshFilter: {fileID: 0}
+  meshRenderer: {fileID: 0}
 --- !u!1 &1022454915919162661
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main_scene.unity
+++ b/Assets/Scenes/Main_scene.unity
@@ -513,6 +513,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Spawner
       objectReference: {fileID: 0}
+    - target: {fileID: 2757748227421460007, guid: 98c98caacaf7f424b888bca8a6de5ae2,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3698618211449862959, guid: 98c98caacaf7f424b888bca8a6de5ae2,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -602,7 +607,7 @@ PrefabInstance:
     - target: {fileID: 4675160465158057465, guid: 98c98caacaf7f424b888bca8a6de5ae2,
         type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 98c98caacaf7f424b888bca8a6de5ae2, type: 3}
@@ -874,7 +879,7 @@ PrefabInstance:
     - target: {fileID: -7102660320631865697, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}
       propertyPath: numToSpawn
-      value: 2500
+      value: 20000
       objectReference: {fileID: 0}
     - target: {fileID: -7102660320631865697, guid: 3d6571ed8ced74e4cad067533607be38,
         type: 3}
@@ -1131,55 +1136,23 @@ PrefabInstance:
       propertyPath: m_CellSwizzle
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5188475410913618776, guid: 3d6571ed8ced74e4cad067533607be38,
+        type: 3}
+      propertyPath: TextureRenderer
+      value: 
+      objectReference: {fileID: 420642528}
+    - target: {fileID: 5188475410913618776, guid: 3d6571ed8ced74e4cad067533607be38,
+        type: 3}
+      propertyPath: meshFilter
+      value: 
+      objectReference: {fileID: 420642530}
+    - target: {fileID: 5188475410913618776, guid: 3d6571ed8ced74e4cad067533607be38,
+        type: 3}
+      propertyPath: meshRenderer
+      value: 
+      objectReference: {fileID: 420642528}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3d6571ed8ced74e4cad067533607be38, type: 3}
---- !u!1 &1963549217 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1022454915255237003, guid: 3d6571ed8ced74e4cad067533607be38,
-    type: 3}
-  m_PrefabInstance: {fileID: 1963549216}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1963549218
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1963549217}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bc66274b4db6d5f418c34677f5077b7a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  birthSystem: {fileID: 1887437310664773286, guid: ac6181b3b20fa014a8be5efc086b250b,
-    type: 3}
-  breedSystem: {fileID: 2429165594321411380, guid: 31e65bad1042b6147b98eb922992e6fa,
-    type: 3}
-  deathSystem: {fileID: 4498131209124397651, guid: f71df26f5a4db3b4a8fd1424fa969922,
-    type: 3}
-  drinkSystem: {fileID: 7902469663851764698, guid: 554e118c3085b734b9f0b535861950a9,
-    type: 3}
-  eatmeatSystem: {fileID: 5406721021189759731, guid: 4ca89f5cba02fd443814125d737bd0cb,
-    type: 3}
-  eatplantSystem: {fileID: 3773439093377776189, guid: 3c63a8aaa38855f41bbe063c6daaa1ac,
-    type: 3}
-  killSystem: {fileID: 8168985824901175513, guid: 8913d7d09fc3a4745a2cc7d814c6196e,
-    type: 3}
---- !u!114 &1963549219
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1963549217}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5cab5d5547a2e85978e7451faba7841c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  TextureRenderer: {fileID: 0}
-  meshFilter: {fileID: 420642530}
-  meshRenderer: {fileID: 420642528}
 --- !u!4 &1963549222 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1022454915255237109, guid: 3d6571ed8ced74e4cad067533607be38,


### PR DESCRIPTION
MapDisplay was missing from the scene causing Unity to crash (at least for me). Animal hitboxes are now smaller (they used to be small but accidentally got reverted in some merge a while ago). The default fox model had some colliders on it that are now disabled.