### PR TITLE
Add smooth look around camera setting

### DIFF
--- a/Assets/Prefabs/Main Camera.prefab
+++ b/Assets/Prefabs/Main Camera.prefab
@@ -101,6 +101,7 @@ MonoBehaviour:
   boostFactor: 2
   zoomSpeed: 1.5
   smoothSpeed: 3
+  smoothLook: 10
   sensitivity: 1
 --- !u!114 &2930296422921347033
 MonoBehaviour:


### PR DESCRIPTION
When looking around with the camera, it turns smoothly instead of
instantly. This is better since precision is not important. The camera movement
now also uses unscaledDeltaTime which fixes the issues it had when changing
the timescale.